### PR TITLE
adding support for component scripts by assigning correct Aliases.

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -295,14 +295,26 @@ Builder.prototype.buildAliases = function(fn){
               if (err) return done(err);
               if (!conf.scripts) return done(null, '');
 
-              var aliases = conf.scripts.map(function(script){
-                var name = builder.conf.name;
-                // TODO: remove special-casing root
-                var alias = self.root
-                  ? self.conf.name + '/deps/' + name + '/' + script
-                  : self.name + '/deps/' + name + '/' + script;
-                var js = 'require.alias("' + builder.name + '/index.js", "' + alias + '");\n';
-                return js;
+              var name = builder.conf.name
+                , scripts = conf.scripts
+                , main = scripts[0];
+
+              if (~scripts.indexOf(conf.main)) {
+                main = conf.main;
+              } else if (~scripts.indexOf('index.js')) {
+                main = 'index.js';
+              }
+
+              // TODO: remove special-casing root
+              var alias = self.root
+                ? self.conf.name + '/deps/' + name
+                : self.name + '/deps/' + name
+
+              var aliases = 'require.alias("' + builder.name + '/' + main + '", "' + alias + '/index.js");\n';
+
+              aliases += scripts.map(function(script) {
+                if (script == 'index.js') return;
+                return 'require.alias("' + builder.name + '/' + script + '", "' + alias + '/' + script + '");\n';
               }).join('');
 
               builder.buildAliases(function(err, str){

--- a/test/builder.js
+++ b/test/builder.js
@@ -40,6 +40,18 @@ describe('Builder', function(){
     })
   })
 
+  describe('.buildAliases(fn)', function(){
+    it('should build default aliases with correct file name', function(done){
+      var builder = new Builder('test/fixtures/alias');
+      builder.buildAliases(function(err, js){
+        if (err) return done(err);
+        var out = read('test/fixtures/alias-js.js', 'utf8');
+        js.should.equal(out);
+        done();
+      });
+    })
+  })
+
   describe('.buildStyles(fn)', function(){
     it('should build the styles', function(done){
       var builder = new Builder('test/fixtures/hello');

--- a/test/fixtures/alias-js.js
+++ b/test/fixtures/alias-js.js
@@ -1,0 +1,14 @@
+require.alias("alias-multi/foo.js", "alias/deps/alias-multi/index.js");
+require.alias("alias-multi/foo.js", "alias/deps/alias-multi/foo.js");
+require.alias("alias-multi/bar.js", "alias/deps/alias-multi/bar.js");
+
+require.alias("alias-multi-index/index.js", "alias/deps/alias-multi-index/index.js");
+require.alias("alias-multi-index/foo.js", "alias/deps/alias-multi-index/foo.js");
+require.alias("alias-multi-index/bar.js", "alias/deps/alias-multi-index/bar.js");
+
+require.alias("alias-single/foo.js", "alias/deps/alias-single/index.js");
+require.alias("alias-single/foo.js", "alias/deps/alias-single/foo.js");
+
+require.alias("alias-main/bar.js", "alias/deps/alias-main/index.js");
+require.alias("alias-main/foo.js", "alias/deps/alias-main/foo.js");
+require.alias("alias-main/bar.js", "alias/deps/alias-main/bar.js");

--- a/test/fixtures/alias-main/bar.js
+++ b/test/fixtures/alias-main/bar.js
@@ -1,0 +1,1 @@
+module.exports = 'bar';

--- a/test/fixtures/alias-main/component.json
+++ b/test/fixtures/alias-main/component.json
@@ -1,0 +1,7 @@
+{
+  "name": "alias-main",
+  "description": "testing main",
+  "version": "0.0.1",
+  "main": "bar.js",
+  "scripts": ["foo.js", "bar.js"]
+}

--- a/test/fixtures/alias-main/foo.js
+++ b/test/fixtures/alias-main/foo.js
@@ -1,0 +1,1 @@
+module.exports = 'foo';

--- a/test/fixtures/alias-multi-index/bar.js
+++ b/test/fixtures/alias-multi-index/bar.js
@@ -1,0 +1,1 @@
+module.exports = 'bar';

--- a/test/fixtures/alias-multi-index/component.json
+++ b/test/fixtures/alias-multi-index/component.json
@@ -1,0 +1,6 @@
+{
+  "name": "alias-multi-index",
+  "description": "multiple scripts component",
+  "version": "0.0.1",
+  "scripts": ["foo.js", "bar.js", "index.js"]
+}

--- a/test/fixtures/alias-multi-index/foo.js
+++ b/test/fixtures/alias-multi-index/foo.js
@@ -1,0 +1,1 @@
+module.exports = 'foo';

--- a/test/fixtures/alias-multi-index/index.js
+++ b/test/fixtures/alias-multi-index/index.js
@@ -1,0 +1,1 @@
+module.exports = 'index';

--- a/test/fixtures/alias-multi/bar.js
+++ b/test/fixtures/alias-multi/bar.js
@@ -1,0 +1,1 @@
+module.exports = 'bar';

--- a/test/fixtures/alias-multi/component.json
+++ b/test/fixtures/alias-multi/component.json
@@ -1,0 +1,6 @@
+{
+  "name": "alias-multi",
+  "description": "multiple scripts component",
+  "version": "0.0.1",
+  "scripts": ["foo.js", "bar.js"]
+}

--- a/test/fixtures/alias-multi/foo.js
+++ b/test/fixtures/alias-multi/foo.js
@@ -1,0 +1,1 @@
+module.exports = 'foo';

--- a/test/fixtures/alias-single/component.json
+++ b/test/fixtures/alias-single/component.json
@@ -1,0 +1,6 @@
+{
+  "name": "alias-single",
+  "description": "multiple scripts component",
+  "version": "0.0.1",
+  "scripts": ["foo.js"]
+}

--- a/test/fixtures/alias-single/foo.js
+++ b/test/fixtures/alias-single/foo.js
@@ -1,0 +1,1 @@
+module.exports = 'foo';

--- a/test/fixtures/alias/boot.js
+++ b/test/fixtures/alias/boot.js
@@ -1,0 +1,2 @@
+module.exports = 'boot'
+console.log(require('alias-multi-index'));

--- a/test/fixtures/alias/component.json
+++ b/test/fixtures/alias/component.json
@@ -1,0 +1,12 @@
+{
+  "name": "alias",
+  "description": "hello world component",
+  "version": "0.0.1",
+  "dependencies": {
+    "alias-multi": "*",
+    "alias-multi-index": "*",
+    "alias-single": "*",
+    "alias-main": "*"
+  },
+  "scripts": ["boot.js"]
+}


### PR DESCRIPTION
Aliases were pointing to `index.js` files that weren't registered for each script inside `component.json`

Now any scripts in `component.json` will be registered under their path and appropriate aliases are set up. 

A default `index.js` alias is setup to the `"main"` script in `components.json`. If there is no `"main"` script set, it will use `index.js` from the `"scripts"` array. If no `index.js` is specified, it will choose the first item in the `"scripts"` array as `index.js` whilst retaining its own path alias.

Pretty sure this gonna do what I want for my project so thought I would share. I would appreciate any thoughts.
