### PR TITLE
Don't rewrite existing data urls

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -666,7 +666,12 @@ function rewriteUrls(builder, file, css) {
     return ~url.indexOf('://');
   }
   
+  function isData(url) {
+    return !!!url.indexOf('data:') // url starts with 'data'
+  }
+  
   function rewrite(url) {
+    if (isData(url)) return url;
     if (isAbsolute(url)) return url;
     var name = normalize(builder.name);
     return join(builder.urlPrefix, '/', name, dirname(file), url);

--- a/test/builder.js
+++ b/test/builder.js
@@ -155,6 +155,7 @@ describe('Builder', function(){
         res.css.should.include('url("build/assets/images/maru.jpeg")');
         res.css.should.include('url("build/assets/images/npm.png")');
         res.css.should.include('url("http://example.com/images/manny.png")');
+        res.css.should.include('url("data:image/png;base64,PNG DATA HERE")');
         done();
       });
     })

--- a/test/fixtures/assets/style.css
+++ b/test/fixtures/assets/style.css
@@ -11,3 +11,7 @@
 #manny {
   background: url(http://example.com/images/manny.png);
 }
+
+#bob {
+  background-image: url(data:image/png;base64,PNG DATA HERE)
+}


### PR DESCRIPTION
Currently, if you have data urls, rework mangles it up, breaking inline pngs. 

Example of a url borked by the builder:

```
from:
data:image/png;base64,iVBORw0KGgoAAAANSA0AAA…
to:
http://localhost:8080/build/persona/data:image/png;base64,iVBORw0KGgoAAAANSA0AAA…
```

This patch will leave data urls as-is when rewriting.
