### PR TITLE
Content filters

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -44,6 +44,7 @@ function Builder(dir, parent) {
     images: [],
     fonts: []
   };
+  this.filters = [];
   this.on('dependency', this.inherit.bind(this));
 }
 
@@ -90,6 +91,7 @@ Builder.prototype.prefixUrls = function(str){
 Builder.prototype.inherit = function(dep){
   dep.paths = this.paths;
   dep.ignored = this.ignored;
+  dep.filters = this.filters;
   dep.prefixUrls(this.urlPrefix);
   dep.copyAssetsTo(this.assetsDest);
 };
@@ -611,6 +613,24 @@ Builder.prototype.buildStyles = function(fn){
 };
 
 /**
+ * Register a file filter to process the file contents
+ * before rendering it
+ *
+ * @param  {String}   ext File extension to match
+ * @param  {Function} fn  Callback function that will receive the file contents
+ * @api public
+ */
+Builder.prototype.registerFilter = function(ext, fn){
+  var self = this;
+  this.filters.push(function (file, body) {
+    if (file.slice(-ext.length) === ext) {
+      return fn.call(self, file, body);
+    }
+    else return body;
+  });
+};
+
+/**
  * No-op processor function.
  */
 
@@ -641,6 +661,10 @@ function register(builder, file, js){
   file =  builder.root
     ? builder.conf.name + '/' + file
     : builder.name + '/' + file;
+
+  builder.filters.forEach(function(fn){
+    js = fn.call(builder, file, js);
+  });
 
   return 'require.register("' + file + '", function(module, exports, require){\n'
     + js

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -622,11 +622,10 @@ Builder.prototype.buildStyles = function(fn){
  */
 Builder.prototype.registerFilter = function(ext, fn){
   var self = this;
-  this.filters.push(function (file, body) {
-    if (file.slice(-ext.length) === ext) {
-      return fn.call(self, file, body);
+  this.filters.push(function (file) {
+    if (file.name.slice(-ext.length) === ext) {
+      fn.call(self, file);
     }
-    else return body;
   });
 };
 
@@ -662,12 +661,13 @@ function register(builder, file, js){
     ? builder.conf.name + '/' + file
     : builder.name + '/' + file;
 
+  var mod = { name: file, body: js };
   builder.filters.forEach(function(fn){
-    js = fn.call(builder, file, js);
+    fn.call(builder, mod);
   });
 
-  return 'require.register("' + file + '", function(module, exports, require){\n'
-    + js
+  return 'require.register("' + mod.name + '", function(module, exports, require){\n'
+    + mod.body
     + '\n});';
 }
 


### PR DESCRIPTION
This allows anyone using builder to register their own content filters without being opinionated. This changes allows someone to register file extensions and pass them through a filter function before they are rendered in the output.

For example, registering '.coffee' filter to allow for writing components in Coffeescript:

``` js
builder.registerFilter('.coffee', function (file) {
    file.body = coffee.compile(file.body, { filename : file.name });
    file.name = file.name.replace('.coffee', '.js');
});
```

You could register filters for template engines as well to automatically compile templates into modules.

While I get why Components are encouraged to be written in pure JS, this change adds enough flexibility for people to write modules in whatever language they want if they're using builder.js directly.

I'll add up some tests and examples when I have some more time.
