### PR TITLE
Bug with main files starting with ./

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -458,6 +458,8 @@ Builder.prototype.buildAliases = function(fn){
               });
 
               if (main) {
+                if(main.slice(0,2) == './') main = main.slice(2);
+                  
                 var alias = self.root
                   ? self.conf.name + '/deps/' + name + '/index.js'
                   : self.name + '/deps/' + name + '/index.js';

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -483,9 +483,13 @@ Builder.prototype.buildAliases = function(fn){
       if (err) return fn(err);
       var conf = self.conf;
       var name = conf.name;
-
-      if (self.root && conf.main) {
-        res.push('require.alias("' + name + '/' + conf.main + '", "' + name + '/index.js");\n');
+      var main = conf.main;
+      
+      if (self.root && main) {
+        
+        if(main.slice(0,2) == './') main = main.slice(2);
+        
+        res.push('require.alias("' + name + '/' + main + '", "' + name + '/index.js");\n');
       }
 
       fn(null, res.join('\n'));


### PR DESCRIPTION
Added code to remove ./ from main file path when defined in component.json. 

I just added component support to Sizzle and the main file is defined using ./ (probably fro bower support). Try installing and using oost/sizzle for an example of why it fails.

Thx
