### PR TITLE
use component name as asset directory name

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -648,7 +648,7 @@ Builder.prototype.buildAsset = function(type, fn){
     if (conf[type]) {
       conf[type].forEach(function(file){
         var path = self.path(file);
-        var name = normalize(self.basename);
+        var name = normalize(conf.name);
         var dest = join(self.assetsDest, name, file);
         batch.push(function(done){
           self.copyTo(path, dest, done);


### PR DESCRIPTION
Currently, it's a bit annoying that the name of the built assets folder is set to the name of the folder the component happens to be checked out to.
