### PR TITLE
support requiring json files

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -830,6 +830,10 @@ function register(builder, file, js){
     ? builder.conf.name + '/' + file
     : builder.basename + '/' + file;
 
+  if (".json" === path.extname(file)) {
+    js = "module.exports = " + js;
+  }
+
   if (builder.sourceUrls) {
     return 'require.register("' + file + '", Function("exports, require, module",\n'
       + JSON.stringify(js + '//@ sourceURL=' + file)


### PR DESCRIPTION
I think json support is quite natural, partly because it is supported in npm, but also because in practice, it is a core part of javascript.

My use case:

In my component.json for my tests i have

``` json
{
 "scripts": [
    "index.js",
    "test-this.js",
    "test-that.js",
    "test-alot-more-like-this.js",
    "component.json"
  ]
}
```

and I'd like to be able to do this in `index.js`

``` javascript
require('./component').scripts.forEach(function (script) {
  if (script.startsWith('test-')) require('./' + script);
})
```
