### PR TITLE
Add a configuration to copy files instead of symlink

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -678,10 +678,18 @@ Builder.prototype.copyTo = function(file, dest, fn){
   mkdir(dir, function(err){
     if (err) return fn(err);
     debug('link %s -> %s', file, dest);
-    fs.symlink(file, dest, function(err){
-      if (err && 'EEXIST' == err.code) return fn(null, dest);
-      fn(err, dest);
-    });
+    if (process.env.COPY === 'true'){
+      var fs_extra = require('fs-extra');
+      fs_extra.copy(file, dest, function(err){
+        if (err && 'EEXIST' == err.code) return fn(null, dest);
+        fn(err, dest);
+      });
+    } else {
+      fs.symlink(file, dest, function(err){
+        if (err && 'EEXIST' == err.code) return fn(null, dest);
+        fn(err, dest);
+      });
+    }
   });
 };
 

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -4,6 +4,7 @@
  */
 
 var fs = require('fs')
+  , cp = require('fs-extra').copy
   , path = require('path')
   , join = path.join
   , dirname = path.dirname
@@ -48,6 +49,7 @@ function Builder(dir, parent) {
     images: [],
     fonts: []
   };
+  this.copy = parent ? parent.copy : false;
   this.on('dependency', this.inherit.bind(this));
 }
 
@@ -110,6 +112,17 @@ Builder.prototype.inherit = function(dep){
 Builder.prototype.development = function(){
   debug('dev dependencies enabled');
   this.dev = true;
+};
+
+/**
+ * Enable "copyFiles" in the build.
+ *
+ * @api public
+ */
+
+Builder.prototype.copyFiles = function(){
+  debug('copy files enabled');
+  this.copy = true;
 };
 
 /**
@@ -673,22 +686,21 @@ Builder.prototype.buildAsset = function(type, fn){
  */
 
 Builder.prototype.copyTo = function(file, dest, fn){
-  var dir = dirname(dest);
+  var dir = dirname(dest)
+    , self = this
+    , done = function(err) {
+      if (err && 'EEXIST' == err.code) return fn(null, dest);
+      fn(err, dest);
+    };
   debug('mkdir -p %s', dir);
   mkdir(dir, function(err){
     if (err) return fn(err);
-    debug('link %s -> %s', file, dest);
-    if (process.env.COPY === 'true'){
-      var fs_extra = require('fs-extra');
-      fs_extra.copy(file, dest, function(err){
-        if (err && 'EEXIST' == err.code) return fn(null, dest);
-        fn(err, dest);
-      });
+    if (self.copy){
+      debug('cp %s -> %s', file, dest);
+      cp(file, dest, done);
     } else {
-      fs.symlink(file, dest, function(err){
-        if (err && 'EEXIST' == err.code) return fn(null, dest);
-        fn(err, dest);
-      });
+      debug('link %s -> %s', file, dest);
+      fs.symlink(file, dest, done);
     }
   });
 };

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "batch": "0.2.1",
     "mkdirp": "0.3.4",
     "debug": "*",
+    "fs-extra": "*",
     "better-assert": "~0.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "batch": "0.2.1",
     "mkdirp": "0.3.4",
     "debug": "*",
-    "fs-extra": "*",
-    "better-assert": "~0.1.0"
+    "better-assert": "~0.1.0",
+    "fs-extra": "~0.5.0"
   },
   "devDependencies": {
     "mocha": "*",

--- a/test/builder.js
+++ b/test/builder.js
@@ -169,6 +169,45 @@ describe('Builder', function(){
       });
     })
 
+    it('should copy .images in COPY=true mode', function(done){
+      process.env.COPY = true;
+      var builder = new Builder('test/fixtures/assets');
+      builder.addLookup('test/fixtures');
+      builder.copyAssetsTo('/tmp/build');
+      builder.build(function(err, res){
+        if (err) return done(err);
+        assert(3 == res.images.length);
+        assert('/tmp/build/assets/images/logo.png' == res.images[0]);
+        assert('/tmp/build/assets/images/maru.jpeg' == res.images[1]);
+        assert('/tmp/build/assets/images/npm.png' == res.images[2]);
+        assert(exists('/tmp/build/assets/images/maru.jpeg'));
+        assert(exists('/tmp/build/assets/images/logo.png'));
+        assert(exists('/tmp/build/assets/images/npm.png'));
+        // images aren't symlinks
+        fs.lstat('/tmp/build/assets/images/npm.png', function(err, stats) {
+          return assert(stats.isSymbolicLink() == false);
+        });
+        done();
+      });
+    })
+
+    it('should copy .files in COPY=true mode', function(done){
+      var builder = new Builder('test/fixtures/assets-parent');
+      builder.addLookup('test/fixtures');
+      builder.copyAssetsTo('/tmp/build');
+      builder.build(function(err, res){
+        if (err) return done(err);
+        assert(1 == res.files.length);
+        assert('/tmp/build/assets/some.txt' == res.files[0]);
+        assert(exists('/tmp/build/assets/some.txt'));
+        // files aren't symlinks
+        fs.lstat('/tmp/build/assets/some.txt', function(err, stats) {
+          return assert(stats.isSymbolicLink() == false);
+        });
+        done();
+      });
+    })
+
     it('should rewrite css urls', function(done){
       var builder = new Builder('test/fixtures/assets-parent');
       builder.addLookup('test/fixtures');

--- a/test/builder.js
+++ b/test/builder.js
@@ -169,9 +169,9 @@ describe('Builder', function(){
       });
     })
 
-    it('should copy .images in COPY=true mode', function(done){
-      process.env.COPY = true;
+    it('should copy .images in copyFiles mode', function(done){
       var builder = new Builder('test/fixtures/assets');
+      builder.copyFiles();
       builder.addLookup('test/fixtures');
       builder.copyAssetsTo('/tmp/build');
       builder.build(function(err, res){
@@ -185,14 +185,15 @@ describe('Builder', function(){
         assert(exists('/tmp/build/assets/images/npm.png'));
         // images aren't symlinks
         fs.lstat('/tmp/build/assets/images/npm.png', function(err, stats) {
-          return assert(stats.isSymbolicLink() == false);
+          assert(stats.isSymbolicLink() == false);
+          done();
         });
-        done();
       });
     })
 
-    it('should copy .files in COPY=true mode', function(done){
+    it('should copy .files in copyFiles mode', function(done){
       var builder = new Builder('test/fixtures/assets-parent');
+      builder.copyFiles();
       builder.addLookup('test/fixtures');
       builder.copyAssetsTo('/tmp/build');
       builder.build(function(err, res){
@@ -202,9 +203,9 @@ describe('Builder', function(){
         assert(exists('/tmp/build/assets/some.txt'));
         // files aren't symlinks
         fs.lstat('/tmp/build/assets/some.txt', function(err, stats) {
-          return assert(stats.isSymbolicLink() == false);
+          assert(stats.isSymbolicLink() == false);
+          done();
         });
-        done();
       });
     })
 


### PR DESCRIPTION
This PR improves #68 by adding the ability to copy files though the similar mechanism as setting a builder in dev mode.
