### PR TITLE
Updating json to return self.conf to avoid race condition

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -366,6 +366,7 @@ Builder.prototype.json = function(fn){
   debug('reading %s', path);
   fs.readFile(path, 'utf8', function(err, str){
     if (err) return fn(err);
+    if (self.conf) return fn(null, self.conf);
     try {
       self.conf = cache[path] = JSON.parse(str);
       // TODO: lame, remove me

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -4,7 +4,7 @@
  */
 
 var Builder = require('..')
-  , Batch  = require('batch')
+  , Batch = require('batch')
   , assert = require('better-assert')
   , exec = require('child_process').exec
   , path = require('path')

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -4,6 +4,7 @@
  */
 
 var Builder = require('..')
+  , Batch  = require('batch')
   , assert = require('better-assert')
   , exec = require('child_process').exec
   , path = require('path')
@@ -18,16 +19,21 @@ var Builder = require('..')
 function ejsPlugin(builder) {
   builder.hook('before scripts', function(pkg, fn){
     var tmpls = pkg.conf.templates;
+    var batch = new Batch;
     if (!tmpls) return fn();
     tmpls.forEach(function(file){
-      var path = pkg.path(file);
-      var str = fs.readFileSync(path, 'utf8');
-      var fn = ejs.compile(str, { client: true, compileDebug: false });
-      var js = 'module.exports = ' + fn;
-      var name = file.split('.')[0] + '.js';
-      pkg.addFile('scripts', name, js);
+      batch.push(function (done) {
+        var path = pkg.path(file);
+        fs.readFile(path, 'utf8', function (err, str) {
+          var fn = ejs.compile(str, { client: true, compileDebug: false });
+          var js = 'module.exports = ' + fn;
+          var name = file.split('.')[0] + '.js';
+          pkg.addFile('scripts', name, js);
+          done();
+        });
+      });
     });
-    fn();
+    batch.end(fn);
   })
 }
 


### PR DESCRIPTION
Hey, we ran across this bug when making a custom build script.

What happens is `Builder.prototype.json` gets called multiple times, and occasionally the `self.conf` [gets overwritten after the callback happens](https://github.com/component/builder.js/blob/master/lib/builder.js#L370). That means that the closured [var for `conf`](https://github.com/component/builder.js/blob/master/lib/builder.js#L559) sometimes differs from `self.conf` when actually building the file. 

This is a small patch to ensure that even if the conf file gets read multiple times, it will return the same conf.

I updated the ejs case to work asynchronously, it fails with the current build but passes with the patch.
