### PR TITLE
Default builder.urlPrefix to empty string. 

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -37,6 +37,7 @@ function Builder(dir, parent) {
   this._hooks = {};
   this._files = {};
   this._js = '';
+  this.urlPrefix = '';
   this.copy = false;
   this.dir = dir;
   this.root = ! parent;


### PR DESCRIPTION
Fixes #75

Related to change in 0.10: [path.resolve and path.join throw a TypeError on non-string input](https://github.com/joyent/node/wiki/Api-changes-between-v0.8-and-v0.10)
