### PR TITLE
Bump fs-extra version

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "mkdirp": "0.3.4",
     "debug": "*",
     "better-assert": "~0.1.0",
-    "fs-extra": "~0.5.0"
+    "fs-extra": "~0.6.0"
   },
   "devDependencies": {
     "mocha": "*",


### PR DESCRIPTION
v0.6.0 has been out for about 20 days now. It's got new versions of ncp and rimraf. The version of ncp was a year old. Ran make test and everything passed so it should be good.
