### PR TITLE
Avoid crashing when a false positive path is found.

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies.
  */
@@ -413,6 +412,12 @@ Builder.prototype.append = function(str){
 Builder.prototype.json = function(){
   var path = this.path('component.json');
   debug('reading %s', path);
+
+  var exist = fs.existsSync(path);
+  
+  if (!exist) {
+    return false;
+  }
 
   // TODO: cache
   var str = read(path, 'utf8');

--- a/test/builder.js
+++ b/test/builder.js
@@ -246,6 +246,16 @@ describe('Builder', function(){
     })
   })
 
+  it('should pass on name collision', function(done){
+    var builder = new Builder('test/fixtures/collision');
+    builder.build(function(err, res){
+      if(err){
+        err.message.should.equal('failed to lookup "bundled"\'s dependency "foo"');
+      }
+      done();
+    })
+  })
+
   it('should not build development dependencies by default', function(done){
     var builder = new Builder('test/fixtures/dev-deps');
     builder.addLookup('test/fixtures');

--- a/test/fixtures/collision/component.json
+++ b/test/fixtures/collision/component.json
@@ -1,0 +1,17 @@
+{
+  "name": "collision",
+  "paths": [
+	"components",
+    "components/main",
+    "lib"
+  ],
+  "local": [
+    "main",
+    "other",
+    "one",
+    "two"
+  ],
+  "scripts": [
+    "index.js"
+  ]
+}

--- a/test/fixtures/collision/components/main/one/component.json
+++ b/test/fixtures/collision/components/main/one/component.json
@@ -1,0 +1,6 @@
+{
+	"name": "one",
+	"scripts": [
+		"index.js"
+	]
+}

--- a/test/fixtures/collision/components/main/one/index.js
+++ b/test/fixtures/collision/components/main/one/index.js
@@ -1,0 +1,1 @@
+module.exports = "one";

--- a/test/fixtures/collision/components/main/two/component.json
+++ b/test/fixtures/collision/components/main/two/component.json
@@ -1,0 +1,6 @@
+{
+	"name": "two",
+	"scripts": [
+		"index.js"
+	]
+}

--- a/test/fixtures/collision/components/main/two/index.js
+++ b/test/fixtures/collision/components/main/two/index.js
@@ -1,0 +1,1 @@
+module.exports = "two";

--- a/test/fixtures/collision/components/other/component.json
+++ b/test/fixtures/collision/components/other/component.json
@@ -1,0 +1,6 @@
+{
+	"name": "other",
+	"scripts": [
+		"index.js"
+	]
+}

--- a/test/fixtures/collision/components/other/index.js
+++ b/test/fixtures/collision/components/other/index.js
@@ -1,0 +1,1 @@
+module.exports = "other";

--- a/test/fixtures/collision/index.js
+++ b/test/fixtures/collision/index.js
@@ -1,0 +1,4 @@
+require('main');
+require('other');
+require('one');
+require('two');

--- a/test/fixtures/collision/lib/main/component.json
+++ b/test/fixtures/collision/lib/main/component.json
@@ -1,0 +1,6 @@
+{
+	"name": "main",
+	"scripts": [
+		"index.js"
+	]
+}

--- a/test/fixtures/collision/lib/main/index.js
+++ b/test/fixtures/collision/lib/main/index.js
@@ -1,0 +1,1 @@
+module.exports = "main";


### PR DESCRIPTION
The building process was crashing when a good path was found but not the one with the `component.json` file.

Might happen when multiple look up paths are set for multiple local component.
