### PR TITLE
root with main breaking runtime

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -546,9 +546,7 @@ Builder.prototype.buildAliases = function(fn){
               : self.basename + '/deps/' + name + '/index.js';
 
             aliases.push(builder.alias(alias, main));
-          }
-
-          if (self.root) {
+          } else if (self.root) {
             aliases.push(builder.alias(name + '/index.js', 'index.js'));
           }
 

--- a/test/builder.js
+++ b/test/builder.js
@@ -354,6 +354,7 @@ describe('Builder', function(){
       if (err) return done(err);
       res.js.should.include('require.alias("boot/boot.js", "boot/index.js")');
       res.js.should.include('require.alias("main/foo.js", "boot/deps/main/index.js")');
+      res.js.should.not.include('require.alias("main/index.js", "main/index.js")');
       done();
     })
   })


### PR DESCRIPTION
If you have a dependency with a different "main" than index.js with the recent root patch it was creating an invalid alias. This fixes it though I'm not sure if it breaks another case. The tests seem to pass though and my app is working as expected again with the root aliases in place.
