### PR TITLE
Adding a call to fs.exists before copying/linking files

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -745,13 +745,17 @@ Builder.prototype.copyTo = function(file, dest, fn){
   debug('mkdir -p %s', dir);
   mkdir(dir, function(err){
     if (err) return fn(err);
-    if (self.copy){
-      debug('cp %s -> %s', file, dest);
-      cp(file, dest, done);
-    } else {
-      debug('link %s -> %s', file, dest);
-      fs.symlink(file, dest, done);
-    }
+    fs.exists(file, function (exists) {
+      if (!exists) return fn(new Error('Path does not exist: ' + file));
+
+      if (self.copy){
+        debug('cp %s -> %s', file, dest);
+        cp(file, dest, done);
+      } else {
+        debug('link %s -> %s', file, dest);
+        fs.symlink(file, dest, done);
+      }
+    });
   });
 };
 


### PR DESCRIPTION
I ran into this while doing component build -c with a file referenced in the component.json that did not exist. Since fstat's error has not .message attribute, all I got was "error: undefined" ... took me a while to figure it out.

Also, without this fix component's linking silently links nonexistent files.
