### PR TITLE
If root set the basename to component.json#name

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -43,7 +43,6 @@ function Builder(dir, parent) {
   this.dir = dir;
   this.root = ! parent;
   this.parent = parent;
-  this.basename = basename(dir);
   this.globalLookupPaths = [];
   this.lookupPaths = [];
   this.ignored = {
@@ -57,6 +56,10 @@ function Builder(dir, parent) {
   // load config
   this.config = this.json();
   this.config.paths = this.config.paths || [];
+  
+  this.basename = this.root
+    ? this.config.name
+    : basename(dir);
 
   // root level lookup paths are
   // applied globally and affect


### PR DESCRIPTION
If the root folder has a different name than the component it breaks when copying assets to the build directory.

For example:

My component is called `my-component`

``` json
// component.json
{
  "name": "my-component",
  "repo": "CamShaft/my-component",
  "version": "0.0.1",
  "dependencies": {},
  "development": {},
  "license": "MIT",
  "scripts": [
    "index.js"
  ]
}
```

It has been cloned into `another-name`

``` sh
$ pwd
/Users/cameron/projects/another-name
```

I build it

``` sh
$ component build
```

and the name in the build directory is the name of the root directory, not the name of the component.

``` sh
$ ll ./build
total 728
drwxr-xr-x   5 cameron  staff   238B May  9 23:19 .
drwxr-xr-x  12 cameron  staff   748B May  9 23:19 ..
drwxr-xr-x   3 cameron  staff   102B May  9 23:19 another-name
-rw-r--r--   1 cameron  staff    74K May  9 23:19 build.css
-rw-r--r--   1 cameron  staff   285K May  9 23:19 build.js
```

When I develop locally I always clone into the component name. However when I deploy to heroku they clone the repo, run the build in a tmp folder i.e. `/tmp/p89yuawdf` and then copy to `/app`.
