### PR TITLE
addSourceURLs

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -16,7 +16,8 @@ var fs = require('fs')
   , mkdir = require('mkdirp')
   , utils = require('./utils')
   , dirname = path.dirname
-  , basename = path.basename;
+  , basename = path.basename
+  , identity = function(x) {return x;};
 
 /**
  * Expose `Builder`.
@@ -125,7 +126,7 @@ Builder.prototype.inherit = function(dep){
   dep.prefixUrls(this.urlPrefix);
   dep.copyAssetsTo(this.assetsDest);
   dep.globalLookupPaths = this.globalLookupPaths;
-  if (this.sourceUrls) dep.addSourceURLs();
+  if (this.sourceUrls) dep.addSourceURLs(this.sourceUrlMapping);
 };
 
 /**
@@ -153,11 +154,13 @@ Builder.prototype.copyFiles = function(){
 /**
  * Enable "sourceURLs" in the build.
  *
+ * @param {[Function]} mapping optional mapping function, receive the built filename as argument
  * @api public
  */
 
-Builder.prototype.addSourceURLs = function(){
+Builder.prototype.addSourceURLs = function(mapping){
   this.sourceUrls = true;
+  this.sourceUrlMapping = mapping || identity;
 };
 
 /**
@@ -909,7 +912,7 @@ function register(builder, file, js){
 
   if (builder.sourceUrls) {
     return 'require.register("' + file + '", Function("exports, require, module",\n'
-      + JSON.stringify(js + '//@ sourceURL=' + file)
+      + JSON.stringify(js + '//@ sourceURL=' + builder.sourceUrlMapping(file))
       + '\n));';
   } else {
     return 'require.register("' + file + '", function(exports, require, module){\n'


### PR DESCRIPTION
Hello TJ, little proposition for **addSourceURLs**
most of my packages use index.js as filename thus when i use  addSourceURLs
and check the sources tab in chrome aIl I see is just see a bunch of index.js files
What do you think about adding this optional mapping function  so I can use something like this to search file more easily 

``` js
  builder.addSourceURLs(function(file) {
    return file.replace('/', '-');
  });
```
