### PR TITLE
Fixed absolute path lookup problem #91

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -6,6 +6,7 @@ var fs = require('fs')
   , cp = require('fs-extra').copy
   , path = require('path')
   , join = path.join
+  , resolve = path.resolve
   , dirname = path.dirname
   , Batch = require('batch')
   , debug = require('debug')('component:builder')
@@ -228,7 +229,7 @@ Builder.prototype.addGlobalRelativeLookup = function(path){
   if (Array.isArray(path)) {
     path.forEach(this.addGlobalRelativeLookup.bind(this));
   } else {
-    this.addLookup(join(this.dir, path));
+    this.addLookup(resolve(this.dir, path));
   }
 
   return this;
@@ -246,7 +247,7 @@ Builder.prototype.addRelativeLookup = function(path){
   if (Array.isArray(path)) {
     path.forEach(this.addRelativeLookup.bind(this));
   } else {
-    this.lookupPaths.push(join(this.dir, path));
+    this.lookupPaths.push(resolve(this.dir, path));
   }
 
   return this;

--- a/test/builder.js
+++ b/test/builder.js
@@ -348,6 +348,42 @@ describe('Builder', function(){
     })
   })
 
+  describe('absolute .paths lookup', function() {
+    var tempComponentPath = path.resolve('test/fixtures/lookups/absolute/component.json');
+    before(function() {
+      // Generate a component.json with an absolute path
+      var lookupPath = path.resolve('test/fixtures');
+      var baseComponent = { 
+        name: "absolute", 
+        description: "a component for testing absolute lookup paths",
+        dependencies: {
+          "component-dialog": "*"
+        },
+        scripts: ["index.js"],
+        paths: [
+          lookupPath
+        ]
+      };
+
+      fs.writeFileSync(tempComponentPath, JSON.stringify(baseComponent));
+    });
+
+    after(function() {
+      // Remove the component.json after the test
+      fs.unlinkSync(tempComponentPath);
+    });
+
+    it('should handle absolute paths', function(done) {
+      var builder = new Builder('test/fixtures/lookups/absolute');
+      builder.build(function(err, res) {
+        if(err) return done(err);
+        var out = read('test/fixtures/lookups-absolute-js.js', 'utf8');
+        res.js.trim().should.equal(out.trim());
+        done();
+      })
+    })
+  })
+
   it('should support "main"', function(done){
     var builder = new Builder('test/fixtures/main-boot');
     builder.addLookup('test/fixtures');


### PR DESCRIPTION
Added new test for absolute path
Updated lib/builder.js

Builder.js will now use absolute paths in the `.paths` config option as it did in a previous version. This should fix the regression noted in #91.
