### PR TITLE
rewrite urls normalized

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -949,19 +949,11 @@ function rewriteUrls(builder, file, css) {
     if (isData(url)) return orig;
     if (isAbsolute(url)) return orig;
     var name = normalize(builder.basename);
-    url = [builder.urlPrefix, name, dirname(file), url].filter(empty).join('/');
+    url = normalize([builder.urlPrefix, name, dirname(file), url].join('/'));
     return 'url("' + url + '")';
   }
 
   return css.replace(/\burl *\(([^)]+)\)/g, rewrite);
-}
-
-/**
- * Empty string filter.
- */
-
-function empty(s) {
-  return '' != s;
 }
 
 /**


### PR DESCRIPTION
I hate to kill the elegant `filter` usage but I have run into cases where I get paths like 'some/./path/url' this fixes it. It still works with empty properties as well.
