### PR TITLE
don't require `fs-extra` just for `copy`

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -3,7 +3,6 @@
  */
 
 var fs = require('fs')
-  , cp = require('fs-extra').copy
   , path = require('path')
   , join = path.join
   , dirname = path.dirname
@@ -15,6 +14,7 @@ var fs = require('fs')
   , exists = fs.existsSync
   , mkdir = require('mkdirp')
   , utils = require('./utils')
+  , cp = utils.copy
   , dirname = path.dirname
   , basename = path.basename;
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,6 @@
 
+var fs = require('fs')
+
 /**
  * Strip `str` quotes.
  *
@@ -22,4 +24,34 @@ exports.stripQuotes = function(str) {
 exports.normalizeConfig = function(conf){
   // support "./" in main
   if (conf.main) conf.main = conf.main.replace(/^\.\//, '');
+};
+
+/**
+ * Copy file `src` to `dest`
+ *
+ * @param {String} src
+ * @param {String} dest
+ * @param {Function} cb
+ * @api private
+ */
+
+exports.copy = function (src, dest, cb) {
+  function next(err) {
+    if (!done) {
+      done = true;
+      cb(err);
+    }
+  }
+
+  var done = false
+    , read = fs.createReadStream(src)
+    , write = fs.createWriteStream(dest);
+
+  write
+    .on('error', next)
+    .on('close', next);
+
+  read
+    .on('error', next)
+    .pipe(write);
 };

--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
     "batch": "0.2.1",
     "mkdirp": "0.3.4",
     "debug": "*",
-    "better-assert": "~0.1.0",
-    "fs-extra": "~0.6.0"
+    "better-assert": "~0.1.0"
   },
   "devDependencies": {
     "mocha": "*",


### PR DESCRIPTION
fs-extra, while well tested, is a heavy dependency just for the sake of `cp(file, dest, done);`.  i've removed the dependency and added a simple `copy` method to `utils`.
