### PR TITLE
allow require('repo-name') inside components

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -535,21 +535,17 @@ Builder.prototype.buildAliases = function(fn){
           if (!conf.scripts) return done(null, '');
           var main = conf.main;
           var name = conf.name;
+          var basename = self.root ? self.config.name : self.basename;
+          var aliases = [];
 
-          var aliases = conf.scripts.map(function(script){
-            var alias = self.root
-              ? self.config.name + '/deps/' + name + '/' + script
-              : self.basename + '/deps/' + name + '/' + script;
-
-            return builder.alias(alias, script);
+          conf.scripts.forEach(function(script){
+            aliases.push(builder.alias(basename + '/deps/' + name + '/' + script, script));
+            aliases.push(builder.alias(basename + '/deps/' + dep +  '/' + script, script));
           });
 
           if (main) {
-            var alias = self.root
-              ? self.config.name + '/deps/' + name + '/index.js'
-              : self.basename + '/deps/' + name + '/index.js';
-
-            aliases.push(builder.alias(alias, main));
+            aliases.push(builder.alias(basename + '/deps/' + name + '/index.js', main));
+            aliases.push(builder.alias(basename + '/deps/' + dep +  '/index.js', main));
           }
 
           if (self.root) {

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -540,12 +540,12 @@ Builder.prototype.buildAliases = function(fn){
 
           conf.scripts.forEach(function(script){
             aliases.push(builder.alias(basename + '/deps/' + name + '/' + script, script));
-            aliases.push(builder.alias(basename + '/deps/' + dep +  '/' + script, script));
+            if (name !== dep) aliases.push(builder.alias(basename + '/deps/' + dep + '/' + script, script));
           });
 
           if (main) {
             aliases.push(builder.alias(basename + '/deps/' + name + '/index.js', main));
-            aliases.push(builder.alias(basename + '/deps/' + dep +  '/index.js', main));
+            if (name !== dep) aliases.push(builder.alias(basename + '/deps/' + dep + '/index.js', main));
           }
 
           if (self.root) {

--- a/test/fixtures/hello-ignore.js
+++ b/test/fixtures/hello-ignore.js
@@ -5,4 +5,5 @@ require.register("hello/bar.js", function(exports, require, module){
 module.exports = 'bar';
 });
 require.alias("component-emitter/index.js", "hello/deps/emitter/index.js");
+require.alias("component-emitter/index.js", "hello/deps/component-emitter/index.js");
 require.alias("component-emitter/index.js", "emitter/index.js");

--- a/test/fixtures/hello.js
+++ b/test/fixtures/hello.js
@@ -8,4 +8,5 @@ require.register("hello/bar.js", function(exports, require, module){
 module.exports = 'bar';
 });
 require.alias("component-emitter/index.js", "hello/deps/emitter/index.js");
+require.alias("component-emitter/index.js", "hello/deps/component-emitter/index.js");
 require.alias("component-emitter/index.js", "emitter/index.js");

--- a/test/fixtures/lookups-absolute-js.js
+++ b/test/fixtures/lookups-absolute-js.js
@@ -8,5 +8,7 @@ require.register("absolute/index.js", function(exports, require, module){
 module.exports = 'absolute'
 });
 require.alias("component-dialog/index.js", "absolute/deps/dialog/index.js");
+require.alias("component-dialog/index.js", "absolute/deps/component-dialog/index.js");
 require.alias("component-dialog/index.js", "dialog/index.js");
 require.alias("component-jquery/index.js", "component-dialog/deps/jquery/index.js");
+require.alias("component-jquery/index.js", "component-dialog/deps/component-jquery/index.js");

--- a/test/fixtures/lookups-deep-js.js
+++ b/test/fixtures/lookups-deep-js.js
@@ -8,5 +8,7 @@ require.register("deep/index.js", function(exports, require, module){
 module.exports = 'deeper'
 });
 require.alias("component-dialog/index.js", "deep/deps/dialog/index.js");
+require.alias("component-dialog/index.js", "deep/deps/component-dialog/index.js");
 require.alias("component-dialog/index.js", "dialog/index.js");
 require.alias("component-jquery/index.js", "component-dialog/deps/jquery/index.js");
+require.alias("component-jquery/index.js", "component-dialog/deps/component-jquery/index.js");


### PR DESCRIPTION
Probably I'm doing something wrong. If I require an other component B inside component A, it is only possible with: `require('name')` but not with `require('repo-name')`.

I might have a special case where I want to be able to use the components on the server side as well. Therefore I added the components folder to the `NODE_PATH`. The problem is that the `require` lookup on the nodejs server does not work with the `require('name').
I am well aware that not all component's work on the server side, but I only need a few to be working. 

Anyway, I think it does not harm if you can include a component with `require('repo-name')` inside another component.
