### PR TITLE
Added registerBuildType Method

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -53,7 +53,7 @@ function Builder(dir, parent) {
 
   // Register internal build types
   this.registerBuildType('scripts', { register: true });
-  this.registerBuildType('templates', { register: true, postProcess: 'strtojs' });
+  this.registerBuildType('templates', { register: true, postProcess: strtojs });
   this._buildTypes.push('aliases');
   this.registerBuildType('styles', rewriteUrls);
   this.registerBuildType('images', {asset: true});
@@ -458,15 +458,7 @@ Builder.prototype.registerBuildType = function(type, options, process) {
   if(options.asset)
     this[buildName] = function(fn) { this.buildAsset(type, fn); }.bind(this);
   else if(options.register) {
-    var postProcess;
-    switch(options.postProcess) {
-      case 'strtojs':
-        postProcess = strtojs;
-        break;
-      default:
-        postProcess = function(str) { return str; };
-        break;
-    }
+    var postProcess = options.postProcess || function(str) { return str; };
     this[buildName] = function(fn) { 
       this.buildType(type, fn, function(builder, file, str) {
         return register(builder, file, postProcess(str));

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -442,7 +442,8 @@ Builder.prototype.json = function(){
 /**
  * Register a build type with builder
  * @param {String} type
- * @param {Object} options
+ * @param {Object} [options]
+ * @param {Function} [process]
  * @api public
  */
 

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -40,6 +40,7 @@ function Builder(dir, parent) {
   this._hooks = {};
   this._files = {};
   this._js = '';
+  this._buildTypes = [];
   this.urlPrefix = '';
   this.copy = false;
   this.dir = dir;
@@ -48,13 +49,16 @@ function Builder(dir, parent) {
   this.globalLookupPaths = [];
   this.lookupPaths = [];
   this.ignored = {
-    scripts: [],
-    styles: [],
-    files: [],
-    images: [],
-    fonts: [],
-    templates: []
   };
+
+  // Register internal build types
+  this.registerBuildType('scripts', { register: true });
+  this.registerBuildType('templates', { register: true, postProcess: 'strtojs' });
+  this._buildTypes.push('aliases');
+  this.registerBuildType('styles', rewriteUrls);
+  this.registerBuildType('images', {asset: true});
+  this.registerBuildType('fonts', {asset: true});
+  this.registerBuildType('files', {asset: true});
 
   // load config
   this.config = this.json();
@@ -436,6 +440,44 @@ Builder.prototype.json = function(){
 };
 
 /**
+ * Register a build type with builder
+ * @param {String} type
+ * @param {Object} options
+ * @api public
+ */
+
+Builder.prototype.registerBuildType = function(type, options, process) {
+  var buildName = 'build' + (type.charAt(0).toUpperCase() + type.slice(1));
+
+  this._buildTypes.push(type);
+  this.ignored[type] = [];
+
+  if(typeof options == 'function') {
+    process = options;
+  }
+  if(options.asset)
+    this[buildName] = function(fn) { this.buildAsset(type, fn); }.bind(this);
+  else if(options.register) {
+    var postProcess;
+    switch(options.postProcess) {
+      case 'strtojs':
+        postProcess = strtojs;
+        break;
+      default:
+        postProcess = function(str) { return str; };
+        break;
+    }
+    this[buildName] = function(fn) { 
+      this.buildType(type, fn, function(builder, file, str) {
+        return register(builder, file, postProcess(str));
+      });
+    }.bind(this);
+  } else {
+    this[buildName] = function(fn) {  this.buildType(type, fn, process); }.bind(this);
+  }
+}
+
+/**
  * Build and invoke `fn(err, res)`, where `res`
  * is an object containing:
  *
@@ -455,13 +497,10 @@ Builder.prototype.build = function(fn){
   var self = this;
   var batch = new Batch;
   debug('building %s', this.dir);
-  batch.push(this.buildScripts.bind(this));
-  batch.push(this.buildTemplates.bind(this));
-  batch.push(this.buildAliases.bind(this));
-  batch.push(this.buildStyles.bind(this));
-  batch.push(this.buildImages.bind(this));
-  batch.push(this.buildFonts.bind(this));
-  batch.push(this.buildFiles.bind(this));
+  for(var i = 0, type; type = this._buildTypes[i]; ++i) {
+    var buildName = 'build' + (type.charAt(0).toUpperCase() + type.slice(1));
+    batch.push(this[buildName].bind(this));
+  }
   batch.end(function(err, res){
     if (err) return fn(err);
 
@@ -471,14 +510,13 @@ Builder.prototype.build = function(fn){
     var custom = self._js;
     var js = [scripts, require, templates, custom].filter(empty).join('\n')
 
-    fn(null, {
-      js: js,
-      css: res.shift(),
-      images: res.shift(),
-      fonts: res.shift(),
-      files: res.shift(),
-      require: requirejs
-    });
+    var ret = { js: js, css: res.shift(), require: requirejs };
+
+    for(var i = 4, buildType; buildType = self._buildTypes[i]; ++ i) {
+      ret[buildType] = res.shift();
+    }
+
+    fn(null, ret);
   });
 };
 
@@ -771,75 +809,6 @@ Builder.prototype.copyTo = function(file, dest, fn){
       }
     });
   });
-};
-
-/**
- * Build `.files` array and invoke `fn(err, paths)`.
- *
- * @param {Function} fn
- * @api private
- */
-
-Builder.prototype.buildFiles = function(fn){
-  this.buildAsset('files', fn);
-};
-
-/**
- * Build `.images` array and invoke `fn(err, paths)`.
- *
- * @param {Function} fn
- * @api private
- */
-
-Builder.prototype.buildImages = function(fn){
-  this.buildAsset('images', fn);
-};
-
-/**
- * Build `.fonts` array and invoke `fn(err, paths)`.
- *
- * @param {Function} fn
- * @api private
- */
-
-Builder.prototype.buildFonts = function(fn){
-  this.buildAsset('fonts', fn);
-};
-
-/**
- * Build scripts and invoke `fn(err, js)`.
- *
- * @param {Function} fn
- * @api private
- */
-
-Builder.prototype.buildScripts = function(fn){
-  this.buildType('scripts', fn, register);
-};
-
-/**
- * Build templates and invoke `fn(err, str)`
- *
- * @param  {Function} fn
- * @api private
- */
-
-Builder.prototype.buildTemplates = function(fn){
-  this.buildType('templates', fn, function(builder, file, str){
-    return register(builder, file, strtojs(str));
-  });
-};
-
-/**
- * Build styles and invoke `fn(err, css)`.
- *
- * @param {Function} fn
- * @api private
- */
-
-Builder.prototype.buildStyles = function(fn){
-  var self = this;
-  this.buildType('styles', fn, rewriteUrls);
 };
 
 /**

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -457,16 +457,16 @@ Builder.prototype.registerBuildType = function(type, options, process) {
     process = options;
   }
   if(options.asset)
-    this[buildName] = function(fn) { this.buildAsset(type, fn); }.bind(this);
+    this[buildName] = function(fn) { this.buildAsset(type, fn); };
   else if(options.register) {
     var postProcess = options.postProcess || function(str) { return str; };
     this[buildName] = function(fn) { 
       this.buildType(type, fn, function(builder, file, str) {
         return register(builder, file, postProcess(str));
       });
-    }.bind(this);
+    };
   } else {
-    this[buildName] = function(fn) {  this.buildType(type, fn, process); }.bind(this);
+    this[buildName] = function(fn) {  this.buildType(type, fn, process); };
   }
 }
 


### PR DESCRIPTION
Added a `registerBuildType` method to allow easier extension of `builder` by plugins. I figure that being able to implement the existing builder methods using this should make it a good starting point. Ultimately it may need some reworking to make it even more extendable, but at least for now it offers a way to add custom asset types, etc. into builder. 

I didn't write tests just because the method is 100% test covered by other tests.
