### PR TITLE
Cache loaded configs

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -415,12 +415,16 @@ Builder.prototype.append = function(str){
  * @return {Object}
  * @api public
  */
-
+Builder.prototype.cachedConfigs = {};
 Builder.prototype.json = function(){
   var path = this.path('component.json');
+  if (this.cachedConfigs[path]) {
+    debug('reading cached %s', path);
+    return this.cachedConfigs[path];
+  }
+  
   debug('reading %s', path);
 
-  // TODO: cache
   var str = read(path, 'utf8');
 
   try {
@@ -431,6 +435,8 @@ Builder.prototype.json = function(){
   }
 
   utils.normalizeConfig(obj);
+  
+  this.cachedConfigs[path] = obj;
 
   return obj;
 };


### PR DESCRIPTION
It is crucial for the loaded configuration files to be persistent so that builder plugins can safely do their `addFile` and `removeFile` calls.

As it is currently, these only affect the one build step where the plugin is called, causing issues with aliasing as reported in anthonyshort/component-coffee#3

There was already a TODO for caching the loaded component manifests, and so this not only makes plugins work better, but should also improve performance.
