### PR TITLE
added support for inheriting development from parent

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -130,6 +130,7 @@ Builder.prototype.inherit = function(dep){
   dep.prefixUrls(this.urlPrefix);
   dep.copyAssetsTo(this.assetsDest);
   dep.globalLookupPaths = this.globalLookupPaths;
+  if (this.dev) dep.development(true);
   if (this.sourceUrls) dep.addSourceURLs();
 };
 

--- a/test/builder.js
+++ b/test/builder.js
@@ -323,6 +323,19 @@ describe('Builder', function(){
         done();
       })
     })
+    it('should include local dep development dependencies', function(done){
+      var builder = new Builder('test/fixtures/dev-deps-local');
+      builder.addLookup('test/fixtures');
+      builder.addLookup('test/fixtures/dev-deps-local');
+      builder.development();
+      builder.build(function(err, res){
+        if (err) return done(err);
+        res.js.should.include('component-emitter/index.js');
+        res.js.should.include('component-jquery/index.js');
+        res.js.should.include('component-dialog/index.js');
+        done();
+      })
+    })
   })
 
   describe('.addSourceURLs()', function() {

--- a/test/fixtures/dev-deps-local/component.json
+++ b/test/fixtures/dev-deps-local/component.json
@@ -1,0 +1,13 @@
+{
+  "name": "popover",
+  "description": "popover component",
+  "dependencies": {
+    "component/emitter": "*"
+  },
+  "development": {
+    "component/jquery": "*"
+  }
+  ,"local": [
+    "other"
+  ]
+}

--- a/test/fixtures/dev-deps-local/other/component.json
+++ b/test/fixtures/dev-deps-local/other/component.json
@@ -1,0 +1,10 @@
+{
+    "name": "other",
+    "description":"other component",
+    "development":{
+        "component/dialog":"*"
+    }
+    ,"scripts":[
+        "index.js"
+    ]
+}

--- a/test/fixtures/dev-deps-local/other/index.js
+++ b/test/fixtures/dev-deps-local/other/index.js
@@ -1,0 +1,1 @@
+module.exports = 'other';


### PR DESCRIPTION
This just extends the 'inherit' builder function to persist the 'dev' of the parent so that local deps can contribute their 'development' dependencies.
