### PR TITLE
rename "lookup" to "resolver"

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -3,7 +3,7 @@
  * Module dependencies.
  */
 
-var lookup = require('./lookup');
+var resolver = require('./resolver');
 var Build = require('./build');
 var Batch = require('batch');
 
@@ -32,7 +32,7 @@ Builder.rewriteUrls = require('./plugins/rewrite-urls');
 
 function Builder(path){
   if (!(this instanceof Builder)) return new Builder(path);
-  this.lookup = lookup(path);
+  this.resolver = resolver(path);
   this.batch = new Batch;
   this.batch.concurrency(1);
 }
@@ -45,7 +45,7 @@ function Builder(path){
 
 Builder.prototype.development = function(){
   this.dev = true;
-  this.lookup.development();
+  this.resolver.development();
   return this;
 };
 
@@ -57,7 +57,7 @@ Builder.prototype.development = function(){
  */
 
 Builder.prototype.path = function(path){
-  this.lookup.add(path);
+  this.resolver.add(path);
   return this;
 };
 
@@ -87,7 +87,7 @@ Builder.prototype.use = function(fn){
 
 Builder.prototype.build = function(fn){
   var self = this;
-  this.lookup.end(function(err, list){
+  this.resolver.end(function(err, list){
     if (err) return fn(err);
     self._build = new Build(list);
     self._build.dev = self.dev;

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -3,7 +3,7 @@
  * Module dependencies.
  */
 
-var resolver = require('./resolver');
+var Resolver = require('./resolver');
 var Build = require('./build');
 var Batch = require('batch');
 
@@ -32,7 +32,7 @@ Builder.rewriteUrls = require('./plugins/rewrite-urls');
 
 function Builder(path){
   if (!(this instanceof Builder)) return new Builder(path);
-  this.resolver = resolver(path);
+  this.resolver = new Resolver(path);
   this.batch = new Batch;
   this.batch.concurrency(1);
 }

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -3,7 +3,7 @@
  * Module dependencies.
  */
 
-var debug = require('debug')('component:builder:lookup');
+var debug = require('debug')('component:builder:resolver');
 var resolve = require('path').resolve;
 var exists = require('fs').exists;
 var read = require('fs').readFile;
@@ -12,54 +12,54 @@ var Batch = require('batch');
 var utils = require('./utils');
 
 /**
- * Expose `Lookup`
+ * Expose `Resolver`
  */
 
-module.exports = Lookup;
+module.exports = Resolver;
 
 /**
- * Initialize a new `Lookup`.
+ * Initialize a new `Resolver`.
  *
  * @param {String} path
- * @param {Lookup} lookup
+ * @param {Resolver} parent
  * @param {Function} fn
  * @api public
  */
 
-function Lookup(path, lookup, fn){
-  if (!(this instanceof Lookup)) return new Lookup(path, lookup, fn);
-  if ('function' == typeof lookup) fn = lookup, lookup = null;
+function Resolver(path, parent, fn){
+  if (!(this instanceof Resolver)) return new Resolver(path, parent, fn);
+  if ('function' == typeof parent) fn = parent, parent = null;
   this.path = path;
-  this.inherit(lookup || {});
+  this.inherit(parent || {});
   if (fn) this.end(fn);
 }
 
 /**
- * Add global lookup `path`.
+ * Add global `path`.
  *
  * @param {String} path
- * @return {Lookup}
+ * @return {Resolver}
  * @api public
  */
 
-Lookup.prototype.add = function(path){
+Resolver.prototype.add = function(path){
   this.paths.push(resolve(this.path, path));
   return this;
 };
 
 /**
- * Inherit `lookup`.
+ * Inherit from a `parent` resolver.
  *
- * @param {Object} lookup
+ * @param {Object} parent
  * @api private
  */
 
-Lookup.prototype.inherit = function(lookup){
-  this.paths = lookup.paths || [this.path + '/components'];
-  this._ignored = lookup._ignored || {};
-  this.cache = lookup.cache || {};
-  this.list = lookup.list || [];
-  this.parent = lookup;
+Resolver.prototype.inherit = function(parent){
+  this.paths = parent.paths || [this.path + '/components'];
+  this._ignored = parent._ignored || {};
+  this.cache = parent.cache || {};
+  this.list = parent.list || [];
+  this.parent = parent;
   this.locals = [];
 };
 
@@ -69,7 +69,7 @@ Lookup.prototype.inherit = function(lookup){
  * @api public
  */
 
-Lookup.prototype.development = function(){
+Resolver.prototype.development = function(){
   this.dev = true;
   return this;
 };
@@ -82,7 +82,7 @@ Lookup.prototype.development = function(){
  * @api private
  */
 
-Lookup.prototype.ignored = function(dep){
+Resolver.prototype.ignored = function(dep){
   dep = dep.replace('/', '-');
   return this._ignored[dep];
 };
@@ -94,7 +94,7 @@ Lookup.prototype.ignored = function(dep){
  * @api private
  */
 
-Lookup.prototype.ignore = function(dep){
+Resolver.prototype.ignore = function(dep){
   if (this.ignored(dep)) return;
   debug('ignore %s', dep);
   dep = dep.replace('/', '-');
@@ -109,7 +109,7 @@ Lookup.prototype.ignore = function(dep){
  * @ap private
  */
 
-Lookup.prototype.json = function(fn){
+Resolver.prototype.json = function(fn){
   var path = join(this.path, 'component.json');
   var self = this;
   read(path, 'utf-8', function(err, str){
@@ -134,7 +134,7 @@ Lookup.prototype.json = function(fn){
  * @api private
  */
 
-Lookup.prototype.end = function(fn){
+Resolver.prototype.end = function(fn){
   var self = this;
   self.json(function(err, conf){
     if (err) return fn(err);
@@ -159,7 +159,7 @@ Lookup.prototype.end = function(fn){
  * @api private
  */
 
-Lookup.prototype.deps = function(done){
+Resolver.prototype.deps = function(done){
   var deps = this.dependencies();
   var names = Object.keys(deps);
   var batch = new Batch;
@@ -175,9 +175,9 @@ Lookup.prototype.deps = function(done){
     if (self.ignored(dep)) return;
     self.ignore(dep);
     batch.push(function(done){
-      self.lookup(dep, function(err, dir){
+      self.resolve(dep, function(err, dir){
         if (err) return done(err);
-        Lookup(dir, self, done);
+        Resolver(dir, self, done);
       });
     });
   });
@@ -193,7 +193,7 @@ Lookup.prototype.deps = function(done){
  * @api public
  */
 
-Lookup.prototype.pull = function(type){
+Resolver.prototype.pull = function(type){
   var all = this.conf[type];
   var self = this;
 
@@ -239,7 +239,7 @@ Lookup.prototype.pull = function(type){
  * @api private
  */
 
-Lookup.prototype.lookup = function(dep, fn){
+Resolver.prototype.resolve = function(dep, fn){
   var paths = this.paths.concat(this.locals);
   var dep = dep.replace('/', '-');
   var name = this.conf.name;
@@ -249,7 +249,7 @@ Lookup.prototype.lookup = function(dep, fn){
 
   function next(){
     var path = paths[i++];
-    if (!path) return fn(new Error('failed to lookup "' + name + '"\'s dependency "' + dep + '"'));
+    if (!path) return fn(new Error('failed to resolve "' + name + '"\'s dependency "' + dep + '"'));
     var dir = join(path, dep);
     var key = dep + ':' + dir;
     if (cache[key]) return fn(null, cache[key]);
@@ -271,7 +271,7 @@ Lookup.prototype.lookup = function(dep, fn){
  * @api public
  */
 
-Lookup.prototype.dependencies = function(){
+Resolver.prototype.dependencies = function(){
   var deps = this.conf.dependencies || {};
   if (this.dev) merge(deps, this.conf.development);
   merge(deps, this.local());
@@ -285,7 +285,7 @@ Lookup.prototype.dependencies = function(){
  * @api private
  */
 
-Lookup.prototype.local = function(){
+Resolver.prototype.local = function(){
   var local = this.conf.local
     || this.conf.locals
     || [];
@@ -303,9 +303,9 @@ Lookup.prototype.local = function(){
  * @api private
  */
 
-Lookup.prototype.map = function(){
-  return this.list.map(function(lookup){
-    return lookup.conf;
+Resolver.prototype.map = function(){
+  return this.list.map(function(resolver){
+    return resolver.conf;
   });
 };
 
@@ -316,7 +316,7 @@ Lookup.prototype.map = function(){
  * @api private
  */
 
-Lookup.prototype.configure = function(conf){
+Resolver.prototype.configure = function(conf){
   var paths = conf.paths || [];
   var self = this;
 

--- a/test/resolver.js
+++ b/test/resolver.js
@@ -1,10 +1,10 @@
 
-var Lookup = require('../lib/lookup');
+var Resolver = require('../lib/resolver');
 
-describe('Lookup', function(){
-  it('should add implicit ./components dir to lookup paths', function(done){
-    var lookup = Lookup('test/fixtures/app');
-    lookup.end(function(err, res){
+describe('Resolver', function(){
+  it('should add implicit ./components dir to resolver paths', function(done){
+    var resolver = Resolver('test/fixtures/app');
+    resolver.end(function(err, res){
       if (err) return done(err);
       res[1].name.should.eql('foo');
       res[2].name.should.eql('bar');
@@ -14,10 +14,10 @@ describe('Lookup', function(){
 
   describe('.development()', function(){
     it('should include development dependencies', function(done){
-      var lookup = new Lookup('test/fixtures/dev-deps');
-      lookup.add('..');
-      lookup.development();
-      lookup.end(function(err, res){
+      var resolver = new Resolver('test/fixtures/dev-deps');
+      resolver.add('..');
+      resolver.development();
+      resolver.end(function(err, res){
         if (err) return done(err);
         res[1].name.should.eql('emitter');
         res[2].name.should.eql('jquery');
@@ -28,7 +28,7 @@ describe('Lookup', function(){
 
   describe('nested', function(){
     it('should work', function(done){
-      var nested = Lookup('test/fixtures/nested');
+      var nested = Resolver('test/fixtures/nested');
       nested.add('..');
       nested.end(function(err, arr){
         if (err) return done(err);
@@ -43,14 +43,14 @@ describe('Lookup', function(){
 
   describe('collision', function(){
     it('should work', function(done){
-      var collision = Lookup('test/fixtures/collision');
+      var collision = Resolver('test/fixtures/collision');
       collision.end(done);
     })
   })
 
   describe('scripts', function(){
     it('should pull them', function(done){
-      var scripts = Lookup('test/fixtures/hello');
+      var scripts = Resolver('test/fixtures/hello');
       scripts.add('..');
       scripts.end(function(err, all){
         if (err) return done(err);
@@ -69,7 +69,7 @@ describe('Lookup', function(){
 
   describe('templates', function(){
     it('should pull them', function(done){
-      var templates = Lookup('test/fixtures/template-strings');
+      var templates = Resolver('test/fixtures/template-strings');
       templates.end(function(err, all){
         if (err) return done(err);
         all.length.should.eql(1);
@@ -83,7 +83,7 @@ describe('Lookup', function(){
 
   describe('styles', function(){
     it('should pull them', function(done){
-      var styles = Lookup('test/fixtures/hello');
+      var styles = Resolver('test/fixtures/hello');
       styles.add('..');
       styles.end(function(err, all){
         if (err) return done(err);
@@ -99,7 +99,7 @@ describe('Lookup', function(){
 
   describe('json', function(){
     it('should pull them', function(done){
-      var json = Lookup('test/fixtures/json');
+      var json = Resolver('test/fixtures/json');
       json.end(function(err, all){
         if (err) return done(err);
         var json = all[0].json.shift();
@@ -111,10 +111,10 @@ describe('Lookup', function(){
   })
 
   describe('failure', function(){
-    it('should error on failed dep lookup', function(done){
-      var failure = Lookup('test/fixtures/bundled');
+    it('should error on failed dep resolver', function(done){
+      var failure = Resolver('test/fixtures/bundled');
       failure.end(function(err){
-        err.message.should.equal('failed to lookup "hello"\'s dependency "foo"');
+        err.message.should.equal('failed to resolve "hello"\'s dependency "foo"');
         done();
       });
     })


### PR DESCRIPTION
since `resolver` is a noun, makes more sense when you're created a new instance of something. and also makes sense cuz i assume we'll want to pull some of that logic out into a shareable `resolver.js`
