### PR TITLE
do not symlink again if symlink already exists

### DIFF
--- a/lib/plugins/copy.js
+++ b/lib/plugins/copy.js
@@ -44,13 +44,16 @@ module.exports = function(type, dest, opts){
         var base = conf.name.replace('/', '-');
         var to = join(dest, base, file);
         var dir = dirname(to);
-        debug('mkdir %s', dir);
-        exists(src, function(exists){
-          if (!exists) return done(new Error('file does not exist: ' + src));
-          mkdirp(dir, function(err){
-            if (err) return done(err);
-            debug('%s %s -> %s', op, src, to);
-            ops[op](src, to, done);
+        exists(to, function(exist){
+          if(exist) return done();
+          exists(src, function(exist){
+            if (!exist) return done(new Error('file does not exist: ' + src));
+            debug('mkdir %s', dir);
+            mkdirp(dir, function(err){
+              if (err) return done(err);
+              debug('%s %s -> %s', op, src, to);
+              ops[op](src, to, done);
+            });
           });
         });
       });


### PR DESCRIPTION
otherwise throws an error on the second time you build:

```
/home/.../index.js:53
      if (err) throw err;
                     ^
Error: EEXIST, symlink '/home/.../fonts/opensans-regular.woff'
make: *** [run-dev] Error 1
```
