### PR TITLE
add build.filter

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -49,3 +49,24 @@ Build.prototype.map = function(type, fn){
     }
   }
 };
+
+/**
+ * Filter files of `type` with `fn(file, conf)`.
+ *
+ * @param {String} type
+ * @param {Function} fn
+ * @api private
+ */
+
+Build.prototype.filter = function(type, fn){
+  for (var i = 0; i < this.components.length; ++i) {
+    var ret = [];
+    var all = this.components[i][type] || [];
+    
+    for (var j = 0; j < all.length; ++j) {
+      if (fn(all[j], this.components[i])) ret.push(all[j]);
+    }
+    
+    this.components[i][type] = ret;
+  }
+};


### PR DESCRIPTION
This allows people to do

``` js
build.filter('templates', function (build, conf){
  ...
  if (ext != '.jade') return true;
  file.contents = jade(file.contents);
  conf.scripts.push(file);
  return false;
});
```

see #157
