### PR TITLE
Fix css dependency ordering

### DIFF
--- a/lib/plugins/commonjs.js
+++ b/lib/plugins/commonjs.js
@@ -28,7 +28,8 @@ module.exports = function(type){
     build.aliases = build.aliases || '';
 
     build.map(type, function(file, conf){
-      var root = conf == build.components[0];
+      var len = build.components.length;
+      var root = conf == build.components[len - 1];
       return register(type, conf, file, root, build.dev);
     });
 
@@ -85,11 +86,12 @@ function register(type, conf, file, root, dev){
  * @api private
  */
 
-function aliases(type, conf, list, dec){
-  var basename = normalize(conf, conf == list[0]);
+function aliases(type, conf, list, dev){
+  var len = list.length;
+  var basename = normalize(conf, conf == list[len - 1]);
   var test = 'ianstormtaylor-bind' == basename;
   var deps = dependencies(conf, list);
-  var root = conf == list[0];
+  var root = conf == list[len - 1];
   var ret = [];
 
   deps.forEach(function(dep){

--- a/lib/plugins/rewrite-urls.js
+++ b/lib/plugins/rewrite-urls.js
@@ -108,7 +108,7 @@ function absolute(url){
  */
 
 function normalize(conf, list){
-  return conf == list[0]
+  return conf == list[list.length - 1]
     ? conf.name
     : basename(conf.path());
 }

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -139,7 +139,6 @@ Resolver.prototype.end = function(fn){
   self.json(function(err, conf){
     if (err) return fn(err);
     var batch = new Batch;
-    self.list.push(self);
     batch.push(self.pull('templates'));
     batch.push(self.pull('scripts'));
     batch.push(self.pull('styles'));
@@ -147,6 +146,7 @@ Resolver.prototype.end = function(fn){
     batch.push(self.deps.bind(self));
     batch.end(function(err){
       if (err) return fn(err);
+      self.list.push(self);
       fn(null, self.map());
     });
   });

--- a/test/concat.js
+++ b/test/concat.js
@@ -1,6 +1,10 @@
-
 var Builder = require('..');
 var concat = Builder.concat;
+
+var Batch = require('batch');
+Batch.prototype.concurrency = function () {
+  this.n = 1;
+};
 
 describe('concat(type)', function(){
   it('should concat `type`', function(done){
@@ -9,7 +13,7 @@ describe('concat(type)', function(){
     builder.use(concat('styles'));
     builder.build(function(err, build){
       if (err) return done(err);
-      build.styles.should.eql('foo {\n  bar: \'baz\';\n}bar {\n  baz: \'raz\';\n}emitter {\n  \n}');
+      build.styles.should.eql('emitter {\n  \n}foo {\n  bar: \'baz\';\n}bar {\n  baz: \'raz\';\n}');
       done();
     });
   })

--- a/test/fixtures/hello-js.js
+++ b/test/fixtures/hello-js.js
@@ -1,9 +1,9 @@
+require.register("component-emitter/index.js", function(exports, require, module){
+module.exports = 'emitter';
+});
 require.register("hello/foo.js", function(exports, require, module){
 module.exports = 'foo';
 });
 require.register("hello/bar.js", function(exports, require, module){
 module.exports = 'bar';
-});
-require.register("component-emitter/index.js", function(exports, require, module){
-module.exports = 'emitter';
 });

--- a/test/resolver.js
+++ b/test/resolver.js
@@ -1,13 +1,18 @@
 
 var Resolver = require('../lib/resolver');
 
+var Batch = require('batch');
+Batch.prototype.concurrency = function () {
+  this.n = 1;
+};
+
 describe('Resolver', function(){
   it('should add implicit ./components dir to resolver paths', function(done){
     var resolver = Resolver('test/fixtures/app');
     resolver.end(function(err, res){
       if (err) return done(err);
       res[1].name.should.eql('foo');
-      res[2].name.should.eql('bar');
+      res[0].name.should.eql('bar');
       done();
     });
   })
@@ -19,8 +24,8 @@ describe('Resolver', function(){
       resolver.development();
       resolver.end(function(err, res){
         if (err) return done(err);
-        res[1].name.should.eql('emitter');
-        res[2].name.should.eql('jquery');
+        res[0].name.should.eql('emitter');
+        res[1].name.should.eql('jquery');
         done();
       })
     })
@@ -33,9 +38,9 @@ describe('Resolver', function(){
       nested.end(function(err, arr){
         if (err) return done(err);
         arr.length.should.eql(3);
-        arr[0].name.should.eql('nested');
+        arr[2].name.should.eql('nested');
         arr[1].name.should.eql('one');
-        arr[2].name.should.eql('two');
+        arr[0].name.should.eql('two');
         done();
       });
     })
@@ -54,7 +59,7 @@ describe('Resolver', function(){
       scripts.add('..');
       scripts.end(function(err, all){
         if (err) return done(err);
-        var hello = all.shift();
+        var hello = all.pop();
         hello.scripts.length.should.eql(2);
         var foo = hello.scripts.shift();
         foo.filename.should.eql('foo.js');
@@ -73,7 +78,7 @@ describe('Resolver', function(){
       templates.end(function(err, all){
         if (err) return done(err);
         all.length.should.eql(1);
-        var tpl = all[0].templates.shift();
+        var tpl = all[0].templates.pop();
         tpl.filename.should.eql('index.html');
         tpl.contents.should.eql('<div></div>');
         done();
@@ -87,7 +92,7 @@ describe('Resolver', function(){
       styles.add('..');
       styles.end(function(err, all){
         if (err) return done(err);
-        var styles = all.shift().styles;
+        var styles = all.pop().styles;
         var foo = styles.shift();
         var bar = styles.shift();
         foo.contents.should.eql('foo {\n  bar: \'baz\';\n}');


### PR DESCRIPTION
Fixes ordering of dependencies. The tests on `master` don't pass consistently on my machine, so I had to set `batch.concurrency` to 1. Should probably be fixed elsewhere. If I'm not mistaken, this also fixes #109, @ianstormtaylor?
